### PR TITLE
Remove logger_json

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,17 +34,10 @@ config :annon_api, :configuration_cache,
 config :annon_api, :plugin_pipeline,
   default_features: []
 
-# Configure JSON Logger back-end
-config :logger_json, :backend,
-  load_from_system_env: true,
-  json_encoder: Poison,
-  metadata: :all
-
 # Do not print debug messages in production
 # and handle all other reports by Elixir Logger with JSON back-end.
 # SASL reports turned off because of their verbosity.
 config :logger,
-  backends: [LoggerJSON],
   level: :info,
   # handle_sasl_reports: true,
   handle_otp_reports: true

--- a/lib/annon_api/plugins/logger.ex
+++ b/lib/annon_api/plugins/logger.ex
@@ -92,7 +92,7 @@ defmodule Annon.Plugins.Logger do
     %{
       status_code: conn.status,
       headers: modify_headers_list(conn.resp_headers),
-      # body: get_response_body(conn)
+      body: "REDACTED"
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Annon.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      extra_applications: [:logger, :logger_json, :confex, :cowboy, :ssl, :plug, :postgrex, :ecto, :joken,
+      extra_applications: [:logger, :confex, :cowboy, :ssl, :plug, :postgrex, :ecto, :joken,
                            :nex_json_schema, :poison, :httpoison, :skycluster, :eview, :dogstat,
                            :ecto_paging, :runtime_tools],
       mod: {Annon, []}
@@ -64,7 +64,6 @@ defmodule Annon.Mixfile do
      {:eview,  ">= 0.0.0"},
      {:ecto_paging, ">= 0.0.0"},
      {:phoenix_ecto, ">= 0.0.0"},
-     {:logger_json, "~> 0.5.0"},
      {:cors_plug, "~> 1.1"},
      {:dogstat, "~> 0.1.0"},
      {:cidr, ">= 1.1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -32,7 +32,6 @@
   "jsone": {:hex, :jsone, "1.3.1", "133be761810ec0e94e05d4156944ffc35d02d6a88fa8fdfc2af29ba53eadb377", [], [], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
   "lager": {:hex, :lager, "3.2.4", "a6deb74dae7927f46bd13255268308ef03eb206ec784a94eaf7c1c0f3b811615", [], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm"},
-  "logger_json": {:hex, :logger_json, "0.5.0", "3b55918e69b380e4e0eab7b72cdfd2442556bf36abc427feebd4792f324d64a1", [:mix], [{:poison, "~> 3.1", [hex: :poison, optional: true]}]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},


### PR DESCRIPTION
App logging code should remain clean. All transformations will happen down the line in the fluentd filter.

As a side effect this should improve app's performance a little.